### PR TITLE
navigation: show the index files first/at the top

### DIFF
--- a/portray/render.py
+++ b/portray/render.py
@@ -197,9 +197,7 @@ def _mkdocs_config(config: dict) -> MkDocsConfig:
 
 
 def _nested_docs(directory: str, root_directory: str, config: dict) -> list:
-    nav = [
-        _doc(doc, root_directory, config) for doc in sorted(glob(os.path.join(directory, "*.md")))
-    ]
+    nav = [_doc(doc, root_directory, config) for doc in _sorted_docs(directory)]
 
     nested_dirs = sorted(glob(os.path.join(directory, "*/")))
     for nested_dir in nested_dirs:
@@ -213,6 +211,16 @@ def _nested_docs(directory: str, root_directory: str, config: dict) -> list:
             nav.append(dir_nav)  # type: ignore
 
     return nav
+
+
+def _sorted_docs(directory: str) -> list:
+    """Get all markdown documents in the directory and sort them, but make sure index.md is first."""
+    docs = sorted(glob(os.path.join(directory, "*.md")))
+    index = os.path.join(directory, "index.md")
+    if docs.__contains__(index):
+        docs.remove(index)
+        docs.insert(0, index)
+    return docs
 
 
 def _label(path: str, config: Dict) -> str:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from hypothesis_auto import auto_test
 from portray import render
 
@@ -7,3 +9,27 @@ def test_mkdocs_config():
         render._mkdocs_config,
         auto_allow_exceptions_=(render._mkdocs_exceptions.ConfigurationError,),
     )
+
+
+def test_document_sort(temporary_dir):
+    temporary_dir = pathlib.Path(temporary_dir)
+
+    # create dummy files: a.md, b.md, c.md, ..., z.md
+    files = []
+    for i in range(ord("a"), ord("z") + 1):
+        file = temporary_dir.joinpath(f"{chr(i)}.md")
+        file.touch()
+        files.append(str(file))
+
+    # sort files (no index.md)
+    docs = render._sorted_docs(temporary_dir)
+    assert docs == files
+
+    # add index.md
+    file = temporary_dir.joinpath("index.md")
+    file.touch()
+    files.insert(0, str(file))  # index.md have to be first!
+
+    # sort files (with index.md)
+    docs = render._sorted_docs(temporary_dir)
+    assert docs == files


### PR DESCRIPTION
Sorting the navigation elements is great but keep the index file first/ at the top.

Also note, that the first element is used/will be shown if someone clicks on the "Reference" link in the main menu and that should be an index file if available.