### PR TITLE
add deep package name support

### DIFF
--- a/docs/quick_start/4.-configuration.md
+++ b/docs/quick_start/4.-configuration.md
@@ -21,6 +21,7 @@ output_dir = "documentation_website"
  - **modules**: A List of Python modules to generate reference documentation for.
  - **append_directory_to_python_path**: If set to `true` (the default) appends the projects root directory to the PYTHON_PATH before producing documentation.
  - **include_reference_documentation**: If set to `true` (the default) automatic reference documentation is produced by pdocs to live alongside your manually written documentation.
+ - **compress_package_names_for_reference_documentation**: If set to `true` (default is `false`), deep packages like `my.company.package_name` will be compressed and the root element within the reference documentation will be `my.company.package_name` instead of dividing each part into its own folder `my -> company -> package_name`.
 
 
 Beyond portray's direct configuration options, you can modify any of MkDocs or pdocs configuration options in the same `pyproject.toml` file.

--- a/portray/config.py
+++ b/portray/config.py
@@ -5,7 +5,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import mkdocs.config as _mkdocs_config  # noqa
 import mkdocs.exceptions as _mkdocs_exceptions  # noqa
@@ -22,6 +22,7 @@ PORTRAY_DEFAULTS = {
     "host": "127.0.0.1",
     "append_directory_to_python_path": True,
     "include_reference_documentation": True,
+    "compress_package_names_for_reference_documentation": False,
     "labels": {"Cli": "CLI", "Api": "API", "Http": "HTTP", "Pypi": "PyPI"},
     "extra_markdown_extensions": [],
 }
@@ -63,6 +64,14 @@ def project(directory: str, config_file: str, **overrides) -> dict:
     project_config.update(toml(os.path.join(directory, config_file)))
     project_config.update(overrides)
 
+    bool_keys = [
+        "append_directory_to_python_path",
+        "include_reference_documentation",
+        "compress_package_names_for_reference_documentation",
+    ]
+    for key in bool_keys:
+        project_config[key] = _str2bool(project_config[key])
+
     project_config.setdefault("modules", [os.path.basename(os.getcwd()).replace("-", "_")])
     project_config.setdefault("pdocs", {}).setdefault("modules", project_config["modules"])
 
@@ -80,6 +89,23 @@ def project(directory: str, config_file: str, **overrides) -> dict:
         )
     project_config["pdocs"] = pdocs(directory, **project_config.get("pdocs", {}))
     return project_config
+
+
+def _str2bool(value: Union[str, bool]) -> bool:
+    """Interpret value as a boolean.
+
+    This code snippet was inspired by <https://stackoverflow.com/a/43357954>.
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    _value = value.strip().lower()
+    if _value in ("yes", "true", "t", "y", "1"):
+        return True
+    elif _value in ("no", "false", "f", "n", "0", ""):
+        return False
+    raise ValueError(f"{value} is not a valid boolean value")
 
 
 def setup_py(location: str) -> dict:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+import pytest
 from hypothesis_auto import auto_test
 from portray import config, exceptions
 
@@ -179,3 +180,14 @@ def test_repository_custom_config(project_dir):
 
 def test_repository_no_config_no_repository(temporary_dir):
     assert config.repository(temporary_dir) == {}
+
+
+def test_str2bool():
+    for value in [True, "yes", "true", "t", "y", "1", "True", "TRUE", "tRuE"]:
+        assert config._str2bool(value) is True
+
+    for value in [False, "no", "false", "f", "n", "0", "False", "FALSE", "fAlSe", "", None]:
+        assert config._str2bool(value) is False
+
+    with pytest.raises(ValueError):
+        config._str2bool("not true or false")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -33,3 +33,11 @@ def test_document_sort(temporary_dir):
     # sort files (with index.md)
     docs = render._sorted_docs(temporary_dir)
     assert docs == files
+
+
+def test_nested_modules_extraction():
+    assert render._remove_nested_modules(["a.b"]) == ["a.b"]
+    assert render._remove_nested_modules(["a.b", "a.b.d"]) == ["a.b"]
+    assert render._remove_nested_modules(["a.b.c", "a.b.d"]) == ["a.b.c", "a.b.d"]
+    assert render._remove_nested_modules(["a.b.c", "a.b.d", "a"]) == ["a"]
+    assert render._remove_nested_modules(["a.b", "a.b.c", "b"]) == ["a.b", "b"]


### PR DESCRIPTION
Only enabled with flag `compress_package_names_for_reference_documentation`. If set to `true` (default is `false`), deep packages like `my.company.package_name` will be compressed and the root element within the reference documentation will be `my.company.package_name` instead of dividing each part into its own folder `my -> company -> package_name`.